### PR TITLE
Adjust CastbarProgressBarNode Internal Nodes Attatch Order

### DIFF
--- a/Nodes/ProgressBar/CastbarProgressBarNode.cs
+++ b/Nodes/ProgressBar/CastbarProgressBarNode.cs
@@ -30,6 +30,20 @@ public class CastBarProgressBarNode : SimpleComponentNode {
 
         BackgroundImageNode.AttachNode(this);
 
+        BorderImageNode = new SimpleNineGridNode {
+            NodeId = 4,
+            Size = new Vector2(160.0f, 20.0f),
+            TextureSize = new Vector2(160.0f, 20.0f),
+            TextureCoordinates = new Vector2(0.0f, 0.0f),
+            NodeFlags = NodeFlags.Visible,
+            PartsRenderType = 4,
+            LeftOffset = 15,
+            RightOffset = 15,
+            TexturePath = "ui/uld/Parameter_Gauge.tex",
+        };
+
+        BorderImageNode.AttachNode(this);
+
         ProgressNode = new SimpleNineGridNode {
             NodeId = 3,
             Size = new Vector2(160.0f, 20.0f),
@@ -45,20 +59,6 @@ public class CastBarProgressBarNode : SimpleComponentNode {
         };
 
         ProgressNode.AttachNode(this);
-
-        BorderImageNode = new SimpleNineGridNode {
-            NodeId = 4,
-            Size = new Vector2(160.0f, 20.0f),
-            TextureSize = new Vector2(160.0f, 20.0f),
-            TextureCoordinates = new Vector2(0.0f, 0.0f),
-            NodeFlags = NodeFlags.Visible,
-            PartsRenderType = 4,
-            LeftOffset = 15,
-            RightOffset = 15,
-            TexturePath = "ui/uld/Parameter_Gauge.tex",
-        };
-
-        BorderImageNode.AttachNode(this);
     }
 
     public float Progress {


### PR DESCRIPTION
if the texture loaded by BorderImageNode doesn't have a transparent zone inside its center, it will hide the color of the ProgressNode, just like this:

<img width="437" height="153" alt="image" src="https://github.com/user-attachments/assets/67a3c8e7-d4f5-4e40-a91e-a23be3df1be7" />

after:

<img width="535" height="233" alt="image" src="https://github.com/user-attachments/assets/74a1d067-c07c-41b7-927f-1564bb2eb74b" />
