### PR TITLE
Make dropdown list fully displayed on screen

### DIFF
--- a/Nodes/DropDown/DropDownNode.cs
+++ b/Nodes/DropDown/DropDownNode.cs
@@ -128,9 +128,8 @@ public abstract class DropDownNode<T, TU> : SimpleComponentNode where T : ListNo
         if (parentAddon is not null) {
 
             if (!IsCollapsed) {
-                OptionListNode.Position = ScreenPosition + Size with {
-                    X = 0.0f,
-                } - new Vector2(parentAddon->X, parentAddon->Y) - new Vector2(0.0f, 4.0f);
+                OptionListNode.Position = ((ScreenPosition - new Vector2(parentAddon->X, parentAddon->Y)) / parentAddon->Scale) + Size with { X = 0.0f } + new Vector2(4.0f, -4.0f);
+                MoveListOnScreen();
 
                 DropDownFocusCollisionNode.Position = -OptionListNode.Position;
                 DropDownFocusCollisionNode.Size = new Vector2(parentAddon->RootNode->Width, parentAddon->RootNode->Height);
@@ -139,6 +138,8 @@ public abstract class DropDownNode<T, TU> : SimpleComponentNode where T : ListNo
             }
             else {
                 OptionListNode.ReattachNode(this);
+                // Need to reset position after reattaching, so screen position is recalculated correctly
+                OptionListNode.Position = Size with { X = 0.0f } + new Vector2(4.0f, -4.0f);
             }
         }
 
@@ -148,6 +149,27 @@ public abstract class DropDownNode<T, TU> : SimpleComponentNode where T : ListNo
         }
         else {
             OnUncollapsed?.Invoke();
+        }
+    }
+    
+    private unsafe void MoveListOnScreen() {
+        var screenSize = AtkStage.Instance()->ScreenSize;
+        var parentAddon = RaptureAtkUnitManager.Instance()->GetAddonByNode(InternalResNode);
+        if (parentAddon == null) {
+            return;
+        }
+
+        var scale = parentAddon->Scale;
+        var scaledListSize = OptionListNode.Size * scale;
+        if (ScreenPosition.X + scaledListSize.X > screenSize.Width) {
+            OptionListNode.X += (screenSize.Width - OptionListNode.ScreenPosition.X - scaledListSize.X - 4f) / scale;
+        }
+        else if (ScreenPosition.X < 0) {
+            OptionListNode.X -= OptionListNode.ScreenPosition.X / scale;
+        }
+
+        if (OptionListNode.ScreenPosition.Y + scaledListSize.Y > screenSize.Height) {
+            OptionListNode.Y += (screenSize.Height - OptionListNode.ScreenPosition.Y - scaledListSize.Y) / scale;
         }
     }
 


### PR DESCRIPTION
I miss understood the ReattachNode and was thinking the parent node instead of the parent addon. Didn't had the issue cause the addon is the parent node in my plugin. 

By the way, may I ask you the reason to reattach the node ? I'm supposing is for the collision/event things, but I struggle to understand those things

Here are the screenshot with the widget app this time on scale 200%.
<img width="1226" height="551" alt="image" src="https://github.com/user-attachments/assets/808daf33-994e-495e-9f6c-519b4a9c3624" />
<img width="1122" height="607" alt="image" src="https://github.com/user-attachments/assets/09493b7b-21d6-4c26-94a1-2f30fe7835be" />
