### PR TITLE
Fix DetachNode not updating addon

### DIFF
--- a/System/NodeBase.Linking.cs
+++ b/System/NodeBase.Linking.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.CompilerServices;
 using FFXIVClientStructs.FFXIV.Client.UI;
 using FFXIVClientStructs.FFXIV.Component.GUI;
@@ -61,6 +61,8 @@ public abstract unsafe partial class NodeBase {
     }
 
     internal void DetachNode() {
+        var parentAddon = ParentAddon;
+
         NodeLinker.DetachNode(InternalResNode);
         InternalResNode->ParentNode = null;
 
@@ -72,9 +74,9 @@ public abstract unsafe partial class NodeBase {
             ParentUldManager = null;
         }
 
-        if (ParentAddon is not null) {
-            ParentAddon->UldManager.UpdateDrawNodeList();
-            ParentAddon->UpdateCollisionNodeList(false);
+        if (parentAddon is not null && parentAddon->UldManager.ResourceFlags.HasFlag(AtkUldManagerResourceFlag.Initialized)) {
+            parentAddon->UldManager.UpdateDrawNodeList();
+            parentAddon->UpdateCollisionNodeList(false);
         }
     }
 


### PR DESCRIPTION
Since `NodeLinker.DetachNode` removes the node from the node tree, ParentAddon (GetAddonByNode) can't find the addon, thus not updating the DrawNodeList and CollisionNodeList.
This caused a TextNode to stay visible for me after I disposed it.