### PR TITLE
Remove TextFlags assignment in LabelTextNode

### DIFF
--- a/Nodes/Basic/LabelTextNode.cs
+++ b/Nodes/Basic/LabelTextNode.cs
@@ -5,7 +5,6 @@ namespace KamiToolKit.Nodes;
 
 public sealed class LabelTextNode : TextNode {
     public LabelTextNode() {
-        TextFlags = TextFlags.Edge;
         TextColor = ColorHelper.GetColor(8); 
         TextOutlineColor = ColorHelper.GetColor(7);
         FontType = FontType.Axis;


### PR DESCRIPTION
Removed setting TextFlags to Edge in LabelTextNode constructor as Edge is not actually a default state for labels. I think this should be opt-in and set by the consumer.