### PR TITLE
Add sound effects to toggling DropDownNodes

### DIFF
--- a/Nodes/Component/LuminaDropDownNode.cs
+++ b/Nodes/Component/LuminaDropDownNode.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Lumina.Excel;
 
 namespace KamiToolKit.Nodes;
@@ -30,7 +30,7 @@ public class LuminaDropDownNode<T> : DropDownNode<LuminaListNode<T>, T> where T 
     private void OptionSelectedHandler(T option) {
         OnOptionSelected?.Invoke(option);
         UpdateLabel(option);
-        Toggle();
+        Toggle(false);
     }
 
     private void ResolveOptions() {

--- a/Nodes/Component/TextDropDownNode.cs
+++ b/Nodes/Component/TextDropDownNode.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace KamiToolKit.Nodes;
@@ -23,7 +23,7 @@ public class TextDropDownNode : DropDownNode<TextListNode, string> {
     private void OptionSelectedHandler(string option) {
         OnOptionSelected?.Invoke(option);
         UpdateLabel(option);
-        Toggle();
+        Toggle(false);
     }
 
     protected override void UpdateLabel(string? option) {


### PR DESCRIPTION
Had to add a parameter so the sound effect can be suppressed when uncollapsing upon selecting an item, because clicking an item is playing a sound itself due to being a button node.
Not sure if this is a good way of doing this. 🤔