### PR TITLE
Fix: Prevent NullReferenceException during NodeBase disposal

### DIFF
--- a/NodeBase/NodeBase.cs
+++ b/NodeBase/NodeBase.cs
@@ -18,6 +18,8 @@ public abstract unsafe partial class NodeBase : IDisposable {
 
     private bool isDisposed;
 
+    private bool isDisposedInternal;
+
     internal abstract AtkResNode* ResNode { get; }
     internal bool IsAddonRootNode;
 
@@ -57,10 +59,14 @@ public abstract unsafe partial class NodeBase : IDisposable {
             Log.Exception(e);
         } 
         finally {
-            Dispose(true, false);
-
-            GC.SuppressFinalize(this);
-            CreatedNodes.Remove(this);
+            if (!isDisposedInternal)
+            {
+                isDisposedInternal = true;
+                
+                Dispose(true, false);
+                GC.SuppressFinalize(this);
+                CreatedNodes.Remove(this);
+            }
         }
     }
 
@@ -85,7 +91,12 @@ public abstract unsafe partial class NodeBase : IDisposable {
         }
     }
 
-    ~NodeBase() => Dispose(false, false);
+    ~NodeBase() {
+        if (isDisposedInternal) return;
+        isDisposedInternal = true;
+        
+        Dispose(false, false);
+    }
 
     /// <summary>
     /// Dispose associated resources. If a resource modifies native state directly guard it with isNativeDestructor


### PR DESCRIPTION
Adds a guard clause (`if (isDisposedInternal) return;`) at the two call sites of `NodeBase.Dispose(bool disposing, bool isNativeDestructor)` to prevent `NullReferenceException` when accessing resources that have already been cleaned up, and to ensure the disposal logic is idempotent.

It appears that a recent regression caused exceptions to be thrown in scenarios that previously worked fine. I think a rework might be best, but I don't want to introduce too many changes.

## Reproduction

**Scenario 1:**
1. Attach `NodeA` to `NodeB`.
2. Dispose `NodeB`.
3. Dispose `NodeA`. -> **Throws Exception**

**Scenario 2:**
1. Add `NodeA` to `OverlayController`.
2. Dispose `NodeA`.
3. Dispose `OverlayController`. -> **Throws Exception**