### PR TITLE
Stop tracking disposed overlay nodes in OverlayController

### DIFF
--- a/NodeBase/NodeBase.Dispose.cs
+++ b/NodeBase/NodeBase.Dispose.cs
@@ -19,6 +19,7 @@ public abstract unsafe partial class NodeBase : IDisposable {
     internal static uint CurrentOffset;
 
     private bool isDisposed;
+    internal event Action<NodeBase>? Disposed;
 
     internal abstract AtkResNode* ResNode { get; }
     internal bool IsAddonRootNode;
@@ -46,6 +47,7 @@ public abstract unsafe partial class NodeBase : IDisposable {
             }
 
             isDisposed = true;
+            NotifyDisposed();
 
             if (!IsNodeValid()) {
                 Services.Log.Warning("Invalid node, dispose aborted.");
@@ -89,6 +91,11 @@ public abstract unsafe partial class NodeBase : IDisposable {
 
     private static void LogIndented(string message)
         => Services.Log.Verbose(new string(' ', logIndent * 2) + message);
+
+    private void NotifyDisposed() {
+        Disposed?.Invoke(this);
+        Disposed = null;
+    }
 
     /// <summary>
     ///     Warning, this is only to ensure there are no memory leaks.
@@ -161,14 +168,17 @@ public abstract unsafe partial class NodeBase : IDisposable {
     }
 
     private void DestructorDetour(AtkResNode* thisPtr, bool free) {
+        if (!isDisposed) {
+            isDisposed = true;
+            NotifyDisposed();
+        }
+
         Dispose(true, true);
         InvokeOriginalDestructor(thisPtr, free);
 
         Services.Log.Verbose($"Native has disposed node {GetType()}");
         GC.SuppressFinalize(this);
         CreatedNodes.Remove(this);
-
-        isDisposed = true;
     }
 
     protected void InvokeOriginalDestructor(AtkResNode* thisPtr, bool free) {

--- a/NodeBase/NodeBase.Dispose.cs
+++ b/NodeBase/NodeBase.Dispose.cs
@@ -19,7 +19,7 @@ public abstract unsafe partial class NodeBase : IDisposable {
     internal static uint CurrentOffset;
 
     private bool isDisposed;
-    internal event Action<NodeBase>? Disposed;
+    internal bool IsDisposed => isDisposed;
 
     internal abstract AtkResNode* ResNode { get; }
     internal bool IsAddonRootNode;
@@ -47,7 +47,6 @@ public abstract unsafe partial class NodeBase : IDisposable {
             }
 
             isDisposed = true;
-            NotifyDisposed();
 
             if (!IsNodeValid()) {
                 Services.Log.Warning("Invalid node, dispose aborted.");
@@ -91,11 +90,6 @@ public abstract unsafe partial class NodeBase : IDisposable {
 
     private static void LogIndented(string message)
         => Services.Log.Verbose(new string(' ', logIndent * 2) + message);
-
-    private void NotifyDisposed() {
-        Disposed?.Invoke(this);
-        Disposed = null;
-    }
 
     /// <summary>
     ///     Warning, this is only to ensure there are no memory leaks.
@@ -168,10 +162,7 @@ public abstract unsafe partial class NodeBase : IDisposable {
     }
 
     private void DestructorDetour(AtkResNode* thisPtr, bool free) {
-        if (!isDisposed) {
-            isDisposed = true;
-            NotifyDisposed();
-        }
+        isDisposed = true;
 
         Dispose(true, true);
         InvokeOriginalDestructor(thisPtr, free);

--- a/Overlay/UiOverlay/OverlayController.cs
+++ b/Overlay/UiOverlay/OverlayController.cs
@@ -15,6 +15,7 @@ public unsafe class OverlayController : IDisposable {
     private readonly Dictionary<OverlayLayer, List<OverlayNode>> overlayNodes = [];
     private readonly Dictionary<OverlayLayer, OverlayAddonState> addonState = [];
 
+    private bool isDisposed;
     private ControllerState controllerState = ControllerState.WaitForNameplate;
 
     public OverlayController() {
@@ -33,10 +34,15 @@ public unsafe class OverlayController : IDisposable {
     }
 
     public void Dispose() {
+        if (isDisposed) return;
+        isDisposed = true;
+
+        Services.Framework.Update -= CheckOverlayState;
         Services.AddonLifecycle.UnregisterListener(AddonEvent.PreFinalize, "NamePlate");
         Services.AddonLifecycle.UnregisterListener(OnOverlayAddonFinalize, OnOverlayAddonUpdate);
 
-        foreach (var node in overlayNodes.SelectMany(nodeList => nodeList.Value)) {
+        foreach (var node in overlayNodes.SelectMany(nodeList => nodeList.Value).ToList()) {
+            node.Disposed -= OnNodeDisposed;
             node.Dispose();
         }
 
@@ -56,11 +62,17 @@ public unsafe class OverlayController : IDisposable {
     }
 
     private void BeginStateCheck() {
+        if (isDisposed) return;
         Services.Framework.Update -= CheckOverlayState;
         Services.Framework.Update += CheckOverlayState;
     }
 
     private void CheckOverlayState(IFramework framework) {
+        if (isDisposed) {
+            Services.Framework.Update -= CheckOverlayState;
+            return;
+        }
+
         switch (controllerState) {
             case ControllerState.WaitForNameplate:
                 CheckNameplateReady();
@@ -125,7 +137,7 @@ public unsafe class OverlayController : IDisposable {
         var addon = RaptureAtkUnitManager.Instance()->GetAddonByName(layer.Description);
         if (addon is null) return;
 
-        foreach (var node in list) {
+        foreach (var node in list.ToList()) {
             AttachNode(addon, node);
         }
     }
@@ -139,10 +151,13 @@ public unsafe class OverlayController : IDisposable {
     });
 
     public void AddNode(OverlayNode node) => Services.Framework.RunOnFrameworkThread(() => {
+        if (isDisposed) return;
+
         overlayNodes.TryAdd(node.OverlayLayer, []);
 
         if (overlayNodes[node.OverlayLayer].Contains(node)) return;
 
+        node.Disposed += OnNodeDisposed;
         overlayNodes[node.OverlayLayer].Add(node);
 
         if (addonState[node.OverlayLayer] is not OverlayAddonState.Ready) return;
@@ -154,9 +169,7 @@ public unsafe class OverlayController : IDisposable {
     });
 
     public void RemoveNode(OverlayNode node) => Services.Framework.RunOnFrameworkThread(() => {
-        if (!overlayNodes.TryGetValue(node.OverlayLayer, out var list)) return;
-
-        if (list.Remove(node)) {
+        if (TryUntrackNode(node)) {
             node.Dispose();
         }
     });
@@ -172,12 +185,14 @@ public unsafe class OverlayController : IDisposable {
     //
 
     private void OnNamePlatePreFinalize(AddonEvent type, AddonArgs args) {
+        if (isDisposed) return;
+
         ClearState();
 
         foreach (var overlayLayer in Enum.GetValues<OverlayLayer>()) {
             if (!overlayNodes.TryGetValue(overlayLayer, out var list)) continue;
 
-            foreach (var node in list) {
+            foreach (var node in list.ToList()) {
                 node.DetachNode();
             }
         }
@@ -186,11 +201,13 @@ public unsafe class OverlayController : IDisposable {
     }
 
     private void OnOverlayAddonFinalize(AddonEvent type, AddonArgs args) {
+        if (isDisposed) return;
+
         var addon = (AtkUnitBase*)args.Addon.Address;
         var overlayLayer = addon->DepthLayer.GetOverlayLayer();
 
         if (overlayNodes.TryGetValue(overlayLayer, out var list)) {
-            foreach (var node in list) {
+            foreach (var node in list.ToList()) {
                 node.DetachNode();
             }
         }
@@ -199,15 +216,34 @@ public unsafe class OverlayController : IDisposable {
     }
 
     private void OnOverlayAddonUpdate(AddonEvent type, AddonArgs args) {
+        if (isDisposed) return;
+
         var addon = (AtkUnitBase*)args.Addon.Address;
         var overlayLayer = addon->DepthLayer.GetOverlayLayer();
 
         if (addonState[overlayLayer] is not OverlayAddonState.Ready) return;
         if (!overlayNodes.TryGetValue(overlayLayer, out var list)) return;
 
-        foreach (var node in list) {
+        foreach (var node in list.ToList()) {
             node.Update();
         }
+    }
+
+    private void OnNodeDisposed(NodeBase node) {
+        if (node is not OverlayNode overlayNode) return;
+        if (isDisposed) return;
+
+        Services.Framework.RunOnFrameworkThread(() => {
+            if (isDisposed) return;
+            TryUntrackNode(overlayNode);
+        });
+    }
+
+    private bool TryUntrackNode(OverlayNode node) {
+        if (!overlayNodes.TryGetValue(node.OverlayLayer, out var list)) return false;
+
+        node.Disposed -= OnNodeDisposed;
+        return list.Remove(node);
     }
 
     //

--- a/Overlay/UiOverlay/OverlayController.cs
+++ b/Overlay/UiOverlay/OverlayController.cs
@@ -42,8 +42,9 @@ public unsafe class OverlayController : IDisposable {
         Services.AddonLifecycle.UnregisterListener(OnOverlayAddonFinalize, OnOverlayAddonUpdate);
 
         foreach (var node in overlayNodes.SelectMany(nodeList => nodeList.Value).ToList()) {
-            node.Disposed -= OnNodeDisposed;
-            node.Dispose();
+            if (!node.IsDisposed) {
+                node.Dispose();
+            }
         }
 
         overlayNodes.Clear();
@@ -132,12 +133,10 @@ public unsafe class OverlayController : IDisposable {
     }
 
     private void AttachAllNodes(OverlayLayer layer) {
-        if (!overlayNodes.TryGetValue(layer, out var list)) return;
-
         var addon = RaptureAtkUnitManager.Instance()->GetAddonByName(layer.Description);
         if (addon is null) return;
 
-        foreach (var node in list.ToList()) {
+        foreach (var node in GetLiveNodes(layer)) {
             AttachNode(addon, node);
         }
     }
@@ -152,12 +151,12 @@ public unsafe class OverlayController : IDisposable {
 
     public void AddNode(OverlayNode node) => Services.Framework.RunOnFrameworkThread(() => {
         if (isDisposed) return;
+        if (node.IsDisposed) return;
 
         overlayNodes.TryAdd(node.OverlayLayer, []);
 
         if (overlayNodes[node.OverlayLayer].Contains(node)) return;
 
-        node.Disposed += OnNodeDisposed;
         overlayNodes[node.OverlayLayer].Add(node);
 
         if (addonState[node.OverlayLayer] is not OverlayAddonState.Ready) return;
@@ -170,7 +169,9 @@ public unsafe class OverlayController : IDisposable {
 
     public void RemoveNode(OverlayNode node) => Services.Framework.RunOnFrameworkThread(() => {
         if (TryUntrackNode(node)) {
-            node.Dispose();
+            if (!node.IsDisposed) {
+                node.Dispose();
+            }
         }
     });
 
@@ -190,9 +191,7 @@ public unsafe class OverlayController : IDisposable {
         ClearState();
 
         foreach (var overlayLayer in Enum.GetValues<OverlayLayer>()) {
-            if (!overlayNodes.TryGetValue(overlayLayer, out var list)) continue;
-
-            foreach (var node in list.ToList()) {
+            foreach (var node in GetLiveNodes(overlayLayer)) {
                 node.DetachNode();
             }
         }
@@ -206,10 +205,8 @@ public unsafe class OverlayController : IDisposable {
         var addon = (AtkUnitBase*)args.Addon.Address;
         var overlayLayer = addon->DepthLayer.GetOverlayLayer();
 
-        if (overlayNodes.TryGetValue(overlayLayer, out var list)) {
-            foreach (var node in list.ToList()) {
-                node.DetachNode();
-            }
+        foreach (var node in GetLiveNodes(overlayLayer)) {
+            node.DetachNode();
         }
 
         addonState[overlayLayer] = OverlayAddonState.None;
@@ -222,28 +219,23 @@ public unsafe class OverlayController : IDisposable {
         var overlayLayer = addon->DepthLayer.GetOverlayLayer();
 
         if (addonState[overlayLayer] is not OverlayAddonState.Ready) return;
-        if (!overlayNodes.TryGetValue(overlayLayer, out var list)) return;
 
-        foreach (var node in list.ToList()) {
+        foreach (var node in GetLiveNodes(overlayLayer)) {
             node.Update();
         }
-    }
-
-    private void OnNodeDisposed(NodeBase node) {
-        if (node is not OverlayNode overlayNode) return;
-        if (isDisposed) return;
-
-        Services.Framework.RunOnFrameworkThread(() => {
-            if (isDisposed) return;
-            TryUntrackNode(overlayNode);
-        });
     }
 
     private bool TryUntrackNode(OverlayNode node) {
         if (!overlayNodes.TryGetValue(node.OverlayLayer, out var list)) return false;
 
-        node.Disposed -= OnNodeDisposed;
         return list.Remove(node);
+    }
+
+    private List<OverlayNode> GetLiveNodes(OverlayLayer layer) {
+        if (!overlayNodes.TryGetValue(layer, out var list)) return [];
+
+        list.RemoveAll(node => node.IsDisposed);
+        return list.ToList();
     }
 
     //


### PR DESCRIPTION
## Background
﻿
I ran into this while debugging an ObjectNullReferrence Exception issue that occurs when logging out and logging back in with a feature using OverlayController in my project.
﻿
Initially, it looked like a timing issue. The first relog would sometimes throw an exception inside `OverlayController.AttachAllNodes`, but subsequent relogs were fine. However, after tracing the actual node lifecycle, I realized the problem went deeper than addon rebuild timing: the controller was holding onto a node that had already been disposed elsewhere. When the next overlay rebuild triggered, it tried to reattach this invalid node.
﻿
## Root Cause
﻿
The underlying issue is that `OverlayController` stores managed `OverlayNode` instances in its tracking lists, assuming they remain valid until explicitly removed via `RemoveNode()`. But that assumption doesn't always hold.
﻿
`NodeBase.Dispose()` is a terminal lifecycle operation—it detaches the node, releases its native resources, and clears the underlying native pointer. Once disposed, a node is no longer safe to touch. Because `OverlayController` had no way of knowing a tracked node had been disposed outside of `RemoveNode()`, it held onto a stale reference. Later, when `CheckOverlayAddonsReady()` called `AttachAllNodes()`, it reached this stale node and tried to assign a new `NodeId`, resulting in a null reference crash.
﻿
Also, I believe that we cannot simply use `Detach` as a cleanup signal here. Overlay nodes are expected to detach temporarily when the native overlay addon is finalized and then reattach when it returns. The true lifecycle boundary is disposal, not detachment.
﻿
## Fix
﻿
To fix this, I made node disposal observable so that `OverlayController` can synchronize its tracking state with the actual node lifetime.
﻿
I added a `Disposed` event on `NodeBase` that fires during both disposal paths:
- The normal managed `Dispose()`
- Native destructor-driven disposal
﻿

`OverlayController` now subscribes to this event when a node is added. If a node is disposed anywhere else, the controller automatically untracks it. This ensures the controller's internal list accurately reflects the actual lifetime of the nodes.
﻿
**Why this approach?**
I intentionally chose an event-based approach over simpler local guards. 
﻿
Adding a validity check inside `AttachAllNodes()` would act as a band-aid—it would prevent the crash at that specific call site, but leave stale entries lingering in the controller. That would keep the ownership model inconsistent and leave the door open for similar bugs in other update or rebuild paths.
﻿
## Additional
While addressing this, I also updated `OverlayController` to properly stop its `Framework.Update` subscription during its own disposal, I switched its internal iteration sites to use snapshots, ensuring that list changes during lifecycle callbacks don't cause collection modification exceptions.