### PR TITLE
NuGet publish action

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -2,6 +2,8 @@ name: Publish NuGet
 
 on:
   push:
+    branches:
+      - master
     tags:
       - "v*"
   workflow_dispatch:
@@ -40,6 +42,7 @@ jobs:
         id: version
         env:
           EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
           REF_NAME: ${{ github.ref_name }}
           MANUAL_VERSION: ${{ inputs.version }}
         run: |
@@ -77,27 +80,82 @@ jobs:
             else
               VER=$(resolve_bump)
             fi
-          else
+          elif [[ "$REF" == refs/tags/* ]]; then
             VER="${REF_NAME#v}"
+          else
+            VER=$(resolve_bump)
           fi
 
           echo "Resolved package version: $VER"
           echo "version=$VER" >> "$GITHUB_OUTPUT"
 
-      - name: Pack
-        run: >
-          dotnet pack KamiToolKit.csproj
-          --configuration Release
-          -p:DALAMUD_HOME=/tmp/dalamud
-          -p:PackageVersion=${{ steps.version.outputs.version }}
-          -p:Version=${{ steps.version.outputs.version }}
-          --output ./artifacts
-
-      - name: Push to NuGet.org
+      - name: Pack and push
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        run: >
-          dotnet nuget push ./artifacts/*.nupkg
-          --api-key "$NUGET_API_KEY"
-          --source https://api.nuget.org/v3/index.json
-          --skip-duplicate
+          INITIAL_VERSION: ${{ steps.version.outputs.version }}
+          IS_TAG_PUSH: ${{ startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          set -euo pipefail
+
+          bump_patch() {
+            local v="$1"
+            local BASE="${v%%-*}"
+            local MA MI PA
+            IFS='.' read -r MA MI PA <<< "$BASE"
+            MA=${MA:-0}
+            MI=${MI:-0}
+            PA=${PA:-0}
+            PA=$((PA + 1))
+            echo "${MA}.${MI}.${PA}"
+          }
+
+          pack() {
+            local ver="$1"
+            rm -rf ./artifacts
+            mkdir -p ./artifacts
+            dotnet pack KamiToolKit.csproj \
+              --configuration Release \
+              -p:DALAMUD_HOME=/tmp/dalamud \
+              -p:PackageVersion="$ver" \
+              -p:Version="$ver" \
+              --output ./artifacts
+          }
+
+          VER="$INITIAL_VERSION"
+          MAX_ATTEMPTS=10
+
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            echo "Pack attempt $attempt / $MAX_ATTEMPTS (version $VER)"
+            pack "$VER"
+
+            set +e
+            dotnet nuget push ./artifacts/*.nupkg \
+              --api-key "$NUGET_API_KEY" \
+              --source https://api.nuget.org/v3/index.json \
+              >push.log 2>&1
+            rc=$?
+            set -e
+
+            if [ "$rc" -eq 0 ]; then
+              echo "Published $VER"
+              exit 0
+            fi
+
+            cat push.log
+
+            if [ "$IS_TAG_PUSH" = "true" ]; then
+              echo "Push failed for tag build; not bumping version."
+              exit "$rc"
+            fi
+
+            if grep -qiE 'already exists|conflict|409' push.log; then
+              VER=$(bump_patch "$VER")
+              echo "Package version already on feed (or pending); bumping to $VER and retrying."
+              continue
+            fi
+
+            exit "$rc"
+          done
+
+          echo "Exceeded $MAX_ATTEMPTS publish attempts."
+          exit 1

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,0 +1,103 @@
+name: Publish NuGet
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version (x.y.z). Leave empty to bump patch."
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      DALAMUD_HOME: /tmp/dalamud
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Download Dalamud
+        run: |
+          set -euo pipefail
+          rm -rf "$DALAMUD_HOME"
+          mkdir -p "$DALAMUD_HOME"
+          ZIP=/tmp/dalamud-latest.zip
+          curl -fsSL "https://goatcorp.github.io/dalamud-distrib/latest.zip" -o "$ZIP"
+          unzip -q "$ZIP" -d "$DALAMUD_HOME"
+
+      - name: Resolve version
+        id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          MANUAL_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          PACKAGE_ID="KamiToolKit"
+          ID_LOWER=$(echo "$PACKAGE_ID" | tr '[:upper:]' '[:lower:]')
+
+          resolve_bump() {
+            local URL="https://api.nuget.org/v3-flatcontainer/${ID_LOWER}/index.json"
+            local HTTP
+            HTTP=$(curl -sSL -o /tmp/nuget-versions.json -w "%{http_code}" "$URL")
+            if [ "$HTTP" != "200" ]; then
+              echo "1.0.0"
+              return 0
+            fi
+            local LATEST
+            LATEST=$(jq -r '(.versions // []) | .[-1] // empty' /tmp/nuget-versions.json)
+            if [ -z "$LATEST" ] || [ "$LATEST" = "null" ]; then
+              echo "1.0.0"
+              return 0
+            fi
+            local BASE="${LATEST%%-*}"
+            local MA MI PA
+            IFS='.' read -r MA MI PA <<< "$BASE"
+            MA=${MA:-0}
+            MI=${MI:-0}
+            PA=${PA:-0}
+            PA=$((PA + 1))
+            echo "${MA}.${MI}.${PA}"
+          }
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ -n "${MANUAL_VERSION:-}" ]; then
+              VER="${MANUAL_VERSION#v}"
+            else
+              VER=$(resolve_bump)
+            fi
+          else
+            VER="${REF_NAME#v}"
+          fi
+
+          echo "Resolved package version: $VER"
+          echo "version=$VER" >> "$GITHUB_OUTPUT"
+
+      - name: Pack
+        run: >
+          dotnet pack KamiToolKit.csproj
+          --configuration Release
+          -p:DALAMUD_HOME=/tmp/dalamud
+          -p:PackageVersion=${{ steps.version.outputs.version }}
+          -p:Version=${{ steps.version.outputs.version }}
+          --output ./artifacts
+
+      - name: Push to NuGet.org
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: >
+          dotnet nuget push ./artifacts/*.nupkg
+          --api-key "$NUGET_API_KEY"
+          --source https://api.nuget.org/v3/index.json
+          --skip-duplicate


### PR DESCRIPTION
Resolve #95. Sorry, was busy this week.

Runs on tag or manually. Can get it to run on commit if you want (it could potentially be a problem with fast commits since I'm not sure if fetching the version works for unvalidated packages). Could also make it run on a fixed schedule if you'd prefer something that basically never requires any kind of intervention

If it's run without a tag it'll fetch the last one and bump the patch (you'll need to run it with a tag at least once so nuget has a version published).

You'll also need to create an api token in nuget, add it to the secrets here under `NUGET_API_KEY`. I also have assumed you will call the package KamiToolKit. If you give it another name you'll need to change L47