### PR TITLE
fix: nodes being out of place on offset maps

### DIFF
--- a/Overlay/MapOverlay/MapMarkerNode.cs
+++ b/Overlay/MapOverlay/MapMarkerNode.cs
@@ -1,4 +1,4 @@
-﻿using System.Numerics;
+using System.Numerics;
 using Dalamud.Interface.Textures.TextureWraps;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 using KamiToolKit.Dalamud;
@@ -100,7 +100,8 @@ public unsafe class MapMarkerNode : SimpleOverlayNode {
         }
 
         var mapScale = mapRow.SizeFactor / 100.0f;
-        var mapOffset = new Vector2(mapRow.OffsetX, mapRow.OffsetY) + new Vector2(1024.0f, 1024.0f);
+        // Fix: For offseted maps, multiply the offset by the scale factor - 1
+        var mapOffset = (new Vector2(mapRow.OffsetX, mapRow.OffsetY) * (mapScale - 1)) + new Vector2(1024.0f, 1024.0f);
 
         base.Size = Size * MarkerScale;
         base.Origin = base.Size / 2.0f;

--- a/Overlay/MapOverlay/MapMarkerNode.cs
+++ b/Overlay/MapOverlay/MapMarkerNode.cs
@@ -100,8 +100,8 @@ public unsafe class MapMarkerNode : SimpleOverlayNode {
         }
 
         var mapScale = mapRow.SizeFactor / 100.0f;
-        // Fix: For offseted maps, multiply the offset by the scale factor - 1
-        var mapOffset = (new Vector2(mapRow.OffsetX, mapRow.OffsetY) * (mapScale - 1)) + new Vector2(1024.0f, 1024.0f);
+        var mapOffset = new Vector2(mapRow.OffsetX, mapRow.OffsetY) * (mapScale - 1);
+        var centerOffset = new Vector2(1024.0f, 1024.0f);
 
         base.Size = Size * MarkerScale;
         base.Origin = base.Size / 2.0f;
@@ -112,7 +112,7 @@ public unsafe class MapMarkerNode : SimpleOverlayNode {
         imGuiImageNode?.Size = base.Size;
         imGuiImageNode?.Origin = base.Size / 2.0f;
         
-        base.Position = Position * mapScale + mapOffset - base.Size / 2.0f;
+        base.Position = Position * mapScale + mapOffset + centerOffset - base.Size / 2.0f;
         base.IsVisible = IsVisible && (AllowAnyMap || AgentMap.Instance()->SelectedMapId == MapId);
     }
 

--- a/Overlay/MapOverlay/MapOverlayController.cs
+++ b/Overlay/MapOverlay/MapOverlayController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Numerics;
 using Dalamud.Game.Addon.Events;
@@ -154,8 +154,8 @@ public unsafe class MapOverlayController : IDisposable {
         // Start with current position
         var offset = new Vector2(areaMap.MapOffsetX, areaMap.MapOffsetY);
 
-        // Add map-specific offset
-        offset += new Vector2(agentMap->CurrentOffsetX, agentMap->CurrentOffsetY);
+        // Add map-specific offset using the selected map
+        offset += new Vector2(agentMap->SelectedOffsetX, agentMap->SelectedOffsetY);
 
         // Set object position relative to center of node
         offset += overlayNode.Size / 2.0f;


### PR DESCRIPTION
As reported by Infi in the past and me from testing, swapping from ImGui to KTK Nodes works mostly OK except for certain maps where it appears they contain a map offset (Subdivisions, Trials, etc.) 

After a few hours of trial and error and wondering why a specific thing worked, it turns out that:
1. Most maps contain a 0,0 offset meaning the math was just `(1024,1024)` while offset maps add some extra calculation making map dimensions different [(-77,0) for Wolves Den].
2. The offset here is what causes the wonkyness as it appears to not scale up to the map's zone scale.
3. In addition, swapping map views causes nodes to share the current map you are in offsets meaning visiting Wolves Den while in New Gridania will result in New Gridania map calculations than Wolves Den' map calculations.

The fix feels almost "What? This literally it?" and honestly I am on the same boat. All I did was swap `agentMap->CurrentOffsetX/Y` to `agentMap->SelectedOffsetX/Y` in the controller while the node takes the map offset and scales it up to the map offset itself (minus 1).

To test, try adding markers in Eureka places, Subdivision areas, The Crown of the Immaculate, Wolves Den and see if those dots differ from ImGui placement. 