### PR TITLE
Move stringbuffer dtor further down

### DIFF
--- a/NodeBase/NodeBase.Tooltips.cs
+++ b/NodeBase/NodeBase.Tooltips.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Utility;
+using Dalamud.Utility;
 using FFXIVClientStructs.FFXIV.Client.Enums;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Component.GUI;
@@ -112,7 +112,6 @@ public unsafe partial class NodeBase {
         if (!TextTooltip.IsEmpty) {
             stringBuffer.SetManagedString(stringBuilder.Builder.Append(TextTooltip).GetViewAsSpan());
         }
-        stringBuffer.Dtor();
 
         var tooltipArgs = new AtkTooltipManager.AtkTooltipArgs();
 


### PR DESCRIPTION
Whoops sorry, I missed the usage under `if (tooltipType.HasFlag(AtkTooltipType.Text)) {`after nebel pointed it out.

Moved it further down