### PR TITLE
Fix TextureImageNode crash on shutdown

### DIFF
--- a/Nodes/Basic/TextureImageNode.cs
+++ b/Nodes/Basic/TextureImageNode.cs
@@ -17,10 +17,6 @@ public unsafe class TextureImageNode : SimpleImageNode {
 
     protected override void Dispose(bool disposing, bool isNativeDestructor) {
         if (disposing) {
-            var asset = PartsList[0]->UldAsset;
-            asset->AtkTexture.KernelTexture = null;
-            asset->AtkTexture.TextureType = 0;
-            
             base.Dispose(disposing, isNativeDestructor);
         }
     }


### PR DESCRIPTION
TextureImageNode is causing the game to crash on shutdown due to this code in Dispose. I'm not 100% sure if this is the best way to fix it; tweak it as necessary.