### PR TITLE
fix: flag markers

### DIFF
--- a/Overlay/MapOverlay/FlagMarkerNode.cs
+++ b/Overlay/MapOverlay/FlagMarkerNode.cs
@@ -8,7 +8,6 @@ public unsafe class FlagMarkerNode : MapMarkerNode {
         IconId = 60561;
         AllowAnyMap = true;
         Size = new Vector2(32.0f, 32.0f);
-        IsPrescaled = true;
     }
 
     protected override void OnUpdate() {
@@ -16,7 +15,12 @@ public unsafe class FlagMarkerNode : MapMarkerNode {
         
         ref var flagMarker = ref agentMap->FlagMapMarkers[0];
         
-        Position = new Vector2(flagMarker.XFloat, flagMarker.YFloat);
+        // For flags, take the map positions of the flag, remove the offset from it
+        // then multiply by mapSize before adding offset back
+        var markerXPos = ((flagMarker.XFloat - agentMap->SelectedOffsetX) * agentMap->SelectedMapSizeFactorFloat) + agentMap->SelectedOffsetX;
+        var markerYPos = ((flagMarker.YFloat - agentMap->SelectedOffsetY) * agentMap->SelectedMapSizeFactorFloat) + agentMap->SelectedOffsetY;
+
+        Position = new Vector2(markerXPos, markerYPos);
         IsVisible = agentMap->FlagMarkerCount is not 0 && flagMarker.TerritoryId == agentMap->SelectedTerritoryId;
 
         base.OnUpdate();

--- a/Overlay/MapOverlay/MapMarkerNode.cs
+++ b/Overlay/MapOverlay/MapMarkerNode.cs
@@ -27,8 +27,6 @@ public unsafe class MapMarkerNode : SimpleOverlayNode {
     public uint MapId { get; set; }
     
     public bool AllowAnyMap { get; set; }
-    
-    internal bool IsPrescaled { get; set; }
 
     public uint? IconId {
         get;
@@ -105,11 +103,6 @@ public unsafe class MapMarkerNode : SimpleOverlayNode {
         var mapOffset = new Vector2(mapRow.OffsetX, mapRow.OffsetY) * (mapScale - 1);
         var centerOffset = new Vector2(1024.0f, 1024.0f);
 
-        if (IsPrescaled) {
-            mapScale *= 2.0f;
-            mapOffset = Vector2.Zero;
-        }
-
         base.Size = Size * MarkerScale;
         base.Origin = base.Size / 2.0f;
 
@@ -119,7 +112,7 @@ public unsafe class MapMarkerNode : SimpleOverlayNode {
         imGuiImageNode?.Size = base.Size;
         imGuiImageNode?.Origin = base.Size / 2.0f;
         
-        base.Position = Position * mapScale + mapOffset + centerOffset - base.Size / 2.0f;
+        base.Position = (Position * mapScale) + mapOffset + centerOffset - (base.Size / 2.0f);
         base.IsVisible = IsVisible && (AllowAnyMap || AgentMap.Instance()->SelectedMapId == MapId);
     }
 


### PR DESCRIPTION
Yet another thing I spend some hours debugging and yet another case of maths.

Basically Flag Markers already contain a offset with them in `XFloat`/`YFloat` from the map so we just remove that first, then scale it up to the map zone size before re-adding the map offset. This removes the need for `IsPrescaled` also and from testing on the Free Trial with every map the Free Trial can see, all maps like the Doman Enclave to Aglaia, Windurst, Kugane Castle, Wolves Den, etc. show exact flag placement for KTK where the in-game flag marker would place the marker in.

I couldn't test any Dawntrail places but given this works from ARR/SB + some SHB/EW raid places, DT should be fine.