### PR TITLE
Allow OverlayNodes to retain visibility when UI is hidden

### DIFF
--- a/NativeAddon/NativeAddon.Flags.cs
+++ b/NativeAddon/NativeAddon.Flags.cs
@@ -27,6 +27,7 @@ public unsafe partial class NativeAddon {
         InternalAddon->DisableFocusOnShow = true;
         InternalAddon->DisableHideTransition = true;
         InternalAddon->DisableShowHideSoundEffects = true;
+        InternalAddon->IgnoreUIDisplayMode = true;
 
         // Disable Controller Nav
         FlagHelper.UpdateFlag(ref InternalAddon->Flags1A2, 0x2, true);

--- a/Overlay/UiOverlay/OverlayNode.cs
+++ b/Overlay/UiOverlay/OverlayNode.cs
@@ -1,4 +1,5 @@
 ﻿using FFXIVClientStructs.FFXIV.Client.UI;
+using FFXIVClientStructs.FFXIV.Component.GUI;
 using KamiToolKit.Enums;
 using KamiToolKit.Premade.Node.Simple;
 
@@ -24,7 +25,7 @@ public abstract unsafe class OverlayNode : SimpleOverlayNode {
         OnUpdate();
 
         var showWithNativeUi = !(HideWithNativeUi && !IsNameplateVisible());
-        var showWithUiToggled = !(HideWithUiToggled && (RaptureAtkUnitManager.Instance()->Flags & AtkUnitManagerFlags.UiHidden) != 0);
+        var showWithUiToggled = !(HideWithUiToggled && IsUiHidden());
 
         base.IsVisible = IsVisible && showWithNativeUi && showWithUiToggled;
     }
@@ -37,4 +38,7 @@ public abstract unsafe class OverlayNode : SimpleOverlayNode {
 
         return nameplateAddon->IsVisible;
     }
+
+    private static bool IsUiHidden()
+        => RaptureAtkUnitManager.Instance()->Flags.HasFlag(AtkUnitManagerFlags.UiHidden);
 }

--- a/Overlay/UiOverlay/OverlayNode.cs
+++ b/Overlay/UiOverlay/OverlayNode.cs
@@ -16,14 +16,17 @@ public abstract unsafe class OverlayNode : SimpleOverlayNode {
     /// <summary>
     ///  When true, this node automatically hides when the Toggle UI Display Mode hotkey is used
     /// </summary>
-    public virtual bool HideWithUIToggled => true;
+    public virtual bool HideWithUiToggled => true;
 
     public override bool IsVisible { get; set; } = true;
 
     public void Update() {
         OnUpdate();
 
-        base.IsVisible = IsVisible && !(HideWithNativeUi && !IsNameplateVisible()) && !(HideWithUIToggled && IsUIHidden());
+        var showWithNativeUi = !(HideWithNativeUi && !IsNameplateVisible());
+        var showWithUiToggled = !(HideWithUiToggled && (RaptureAtkUnitManager.Instance()->Flags & AtkUnitManagerFlags.UiHidden) != 0);
+
+        base.IsVisible = IsVisible && showWithNativeUi && showWithUiToggled;
     }
 
     protected abstract void OnUpdate();
@@ -34,6 +37,4 @@ public abstract unsafe class OverlayNode : SimpleOverlayNode {
 
         return nameplateAddon->IsVisible;
     }
-
-    private static bool IsUIHidden() => (RaptureAtkUnitManager.Instance()->Flags & AtkUnitManagerFlags.UiHidden) != 0;
 }

--- a/Overlay/UiOverlay/OverlayNode.cs
+++ b/Overlay/UiOverlay/OverlayNode.cs
@@ -13,12 +13,17 @@ public abstract unsafe class OverlayNode : SimpleOverlayNode {
     /// </summary>
     public virtual bool HideWithNativeUi => true;
 
+    /// <summary>
+    ///  When true, this node automatically hides when the Toggle UI Display Mode hotkey is used
+    /// </summary>
+    public virtual bool HideWithUIToggled => true;
+
     public override bool IsVisible { get; set; } = true;
 
     public void Update() {
         OnUpdate();
 
-        base.IsVisible = IsVisible && !(HideWithNativeUi && !IsNameplateVisible());
+        base.IsVisible = IsVisible && !(HideWithNativeUi && !IsNameplateVisible()) && !(HideWithUIToggled && IsUIHidden());
     }
 
     protected abstract void OnUpdate();
@@ -29,4 +34,6 @@ public abstract unsafe class OverlayNode : SimpleOverlayNode {
 
         return nameplateAddon->IsVisible;
     }
+
+    private static bool IsUIHidden() => (RaptureAtkUnitManager.Instance()->Flags & AtkUnitManagerFlags.UiHidden) != 0;
 }


### PR DESCRIPTION
relies on this CS PR adding the IgnoreUIDisplayMode bool to AtkBaseUnits: https://github.com/aers/FFXIVClientStructs/pull/1823

making this as a draft for both feedback on the concept, and b/c I haven't been able to test locally yet

- adds IgnoreUIDisplayMode to all OverlayAddons - this keeps them visible (but uninteractable) when the UI is hidden with the `Toggle UI Display Mode` hotkey in vanilla
- to prevent every OverlayNode from being drawn when the UI is meant to be hidden, adds a `HideWithUIToggled` bool set to True to OverlayNodes
- compares the UiHidden flag on AtkUnitManager with `HideWithUiToggled` each update in OverlayNode to determine visibility conditions, similarly to `HideWithNativeUi`