### PR TITLE
Properly clean up mousewheel events

### DIFF
--- a/BaseTypes/NodeBase/NodeBase.Dispose.cs
+++ b/BaseTypes/NodeBase/NodeBase.Dispose.cs
@@ -34,6 +34,8 @@ public abstract unsafe partial class NodeBase : IDisposable {
     /// </summary>
     protected bool IsDisposed { get; private set; }
 
+    private bool isDisposing;
+
     /// <summary>
     /// Disposes this instance. Has double dispose guards.
     /// </summary>
@@ -46,7 +48,7 @@ public abstract unsafe partial class NodeBase : IDisposable {
             LogIndented($"Beginning Dispose for {GetType()}", true);
             logIndent++;
 
-            if (IsDisposed) {
+            if (IsDisposed || isDisposing) {
                 LogIndented("Node was already disposed, skipping.", EnableFullLogging);
                 return;
             }
@@ -61,12 +63,16 @@ public abstract unsafe partial class NodeBase : IDisposable {
                 return;
             }
 
-            IsDisposed = true;
+            isDisposing = true;
 
             if (!IsNodeValid()) {
                 Services.Log.Warning("Invalid node, dispose aborted.");
+                IsDisposed = true;
                 return;
             }
+
+            LogIndented("Running Pre-Child Dispose", EnableFullLogging);
+            OnBeforeDisposeChildren();
 
             LogIndented("Disposing Children", EnableFullLogging);
             foreach (var child in ChildNodes.ToList()) {
@@ -92,10 +98,12 @@ public abstract unsafe partial class NodeBase : IDisposable {
             Dispose(true, false);
             GC.SuppressFinalize(this);
             CreatedNodes.Remove(this);
+            IsDisposed = true;
         }
         catch (Exception e) {
             Services.Log.Exception(e);
         } finally {
+            isDisposing = false;
             logIndent--;
             LogIndented("Dispose Complete", true);
             logIndent--;
@@ -177,6 +185,11 @@ public abstract unsafe partial class NodeBase : IDisposable {
         DisposeEvents();
         DisableEditMode(NodeEditMode.Move | NodeEditMode.Resize);
     }
+
+    /// <summary>
+    /// Runs before child nodes are disposed during manual disposal.
+    /// </summary>
+    protected virtual void OnBeforeDisposeChildren() { }
 
     private bool IsNodeValid() {
         if (ResNode is null) return false;

--- a/Nodes/ComponentNode/ScrollingNode.cs
+++ b/Nodes/ComponentNode/ScrollingNode.cs
@@ -127,6 +127,15 @@ public class ScrollingNode<T> : ResNode where T : NodeBase, new() {
             ScrollBarNode,
             false
         );
+
+        mouseWheelEventsRegistered = true;
+    }
+
+    /// <inheritdoc />
+    protected override void OnBeforeDisposeChildren() {
+        UnregisterMouseWheelEvents();
+
+        base.OnBeforeDisposeChildren();
     }
 
     /// <inheritdoc />
@@ -148,4 +157,33 @@ public class ScrollingNode<T> : ResNode where T : NodeBase, new() {
         ScrollBarNode.SetContentNodes(ContentNode, ScrollingCollisionNode);
         ScrollBarNode.ScrollPosition = Math.Clamp(oldPosition, 0, ScrollBarNode.ScrollMaxPosition);
     }
+
+    private unsafe void UnregisterMouseWheelEvents() {
+        if (!mouseWheelEventsRegistered) return;
+
+        mouseWheelEventsRegistered = false;
+
+        ClippingContentNode.ResNode->AtkEventManager.UnregisterEvent(
+            AtkEventType.MouseWheel,
+            5,
+            ScrollBarNode,
+            false
+        );
+
+        ScrollingCollisionNode.ResNode->AtkEventManager.UnregisterEvent(
+            AtkEventType.MouseWheel,
+            5,
+            ScrollBarNode,
+            false
+        );
+
+        ContentNode.ResNode->AtkEventManager.UnregisterEvent(
+            AtkEventType.MouseWheel,
+            5,
+            ScrollBarNode,
+            false
+        );
+    }
+
+    private bool mouseWheelEventsRegistered;
 }


### PR DESCRIPTION
Had some crashes specifically when working with ScrollingNode and in some instances it would crash after a few seconds even when the window was closed: 

```
CLR error occurred
Dump at: C:\Users\Jeffro\AppData\Roaming\XIVLauncher\dalamud_appcrash_20260704_014955_879_38524.dmp
System Time: 2026-07-03 23:49:58.5300463 +00:00
CPU Vendor: AuthenticAMD
CPU Brand: AMD Ryzen 7 7800X3D 8-Core Processor           
GPU Desc: NVIDIA GeForce RTX 4070 SUPER
GPU Desc: AMD Radeon(TM) Graphics
GPU Desc: NVIDIA GeForce RTX 4070 SUPER
GPU Desc: Microsoft Basic Render Driver

Additional Information
{
Application: ffxiv_dx11.exe
CoreCLR Version: 10.0.25.52411
.NET Version: 10.0.0
Description: The application requested process termination through System.Environment.FailFast.
Message: A callback was made on a garbage collected delegate of type 'FFXIVClientStructs!FFXIVClientStructs.FFXIV.Component.GUI.AtkEventListener+Delegates+ReceiveEvent::Invoke'.
Stack:
   at Dalamud.Game.Framework.HandleFrameworkUpdate(FFXIVClientStructs.FFXIV.Client.System.Framework.Framework*)

}

Exception Info #0
Address: 12345679
Flags: 80
Address: 7FFB11101C0A

Thread: 0xDF8
Call Stack
{
  [0]	KERNELBASE.dll+C1C0A	(RaiseException+0x8A)
  [1]	Dalamud.Boot.dll+6731C	(GetDllChangedStorage+0x466CC)
  [2]	Dalamud.Boot.dll+6A190	(GetDllChangedStorage+0x49540)
  [3]	2808D5E0AF3
  [4]	D0BCCFD468
  [5]	29291FB3590
  [6]	ILStubClass.IL_STUB_PInvoke(FFXIVClientStructs.FFXIV.Client.System.Framework.Framework*)
  [7]	Dalamud.Game.Framework.HandleFrameworkUpdate(FFXIVClientStructs.FFXIV.Client.System.Framework.Framework*)
  [8]	ILStubClass.IL_STUB_ReversePInvoke(FFXIVClientStructs.FFXIV.Client.System.Framework.Framework*)
  [9]	ffxiv_dx11.exe+5BAB5	(sub_14005B940+0x175)
  [10]	ffxiv_dx11.exe+5EFE5	(WinMain+0x1355)
  [11]	ffxiv_dx11.exe+1D946AE	(__scrt_common_main_seh+0x106)
  [12]	KERNEL32.DLL+2E957	(BaseThreadInitThunk+0x17)
  [13]	ntdll.dll+AAD6C	(RtlUserThreadStart+0x2C)
}

Registers
{
  RAX:	RPCRT4.dll+408EA	(RpcExceptionFilter+0x74BA)
  RBX:	0
  RCX:	0
  RDX:	ADVAPI32.dll+75690	(OpenThreadWaitChainSession+0xC6C0)
  R8:	0
  R9:	29200000000 [9F5D9F5C9F5B9F59]
  R10:	D0BCCFC078 [29292078920]
  R11:	29291F035A0 [7FF900000002]
  R12:	0
  R13:	0
  R14:	2903DC8D888 [2903DC8D820]
  R15:	1
  RSI:	0
  RDI:	12345679
  RBP:	0
  RSP:	D0BCCFCCF0 [291BE21C420]
  RIP:	KERNELBASE.dll+C1C0A	(RaiseException+0x8A)
}

Stack
{
  [RSP+0]	291BE21C420 [29293A2EE20]
  [RSP+8]	0
  [RSP+10]	0
  [RSP+18]	12345679
  [RSP+20]	8012345679
  [RSP+28]	0
  [RSP+30]	KERNELBASE.dll+C1C0A	(RaiseException+0x8A)
  [RSP+38]	0
  [RSP+40]	0
  [RSP+48]	0
  [RSP+50]	0
  [RSP+58]	0
  [RSP+60]	0
  [RSP+68]	0
  [RSP+70]	0
  [RSP+78]	0
}
```